### PR TITLE
fix race condition in exponential backoff

### DIFF
--- a/exponential.go
+++ b/exponential.go
@@ -42,7 +42,6 @@ func NewExponential(options ...Option) *Exponential {
 		maxElapsedTime: maxElapsedTime,
 		maxInterval:    maxInterval,
 		maxRetries:     maxRetries,
-		random:         rand.New(rand.NewSource(time.Now().UnixNano())),
 		threshold:      threshold,
 	}
 }
@@ -68,6 +67,7 @@ func (p *Exponential) Start(ctx context.Context) (Backoff, CancelFunc) {
 	b.baseBackoff = newBaseBackoff(ctx, p.maxRetries, p.maxElapsedTime)
 	b.policy = p
 	b.attempt = 0
+	b.random = rand.New(rand.NewSource(time.Now().UnixNano()))
 	b.baseBackoff.Start(ctx)
 
 	b.mu.Lock()
@@ -102,7 +102,7 @@ func (b *exponentialBackoff) delayForAttempt(attempt float64) time.Duration {
 		jitteredMin := durf - jitterDelta
 		jitteredMax := durf + jitterDelta
 
-		durf = jitteredMin + b.policy.random.Float64()*(jitteredMax-jitteredMin+1)
+		durf = jitteredMin + b.random.Float64()*(jitteredMax-jitteredMin+1)
 	}
 
 	if maxf := b.policy.maxInterval; maxf > 0 && durf > maxf {

--- a/interface.go
+++ b/interface.go
@@ -72,12 +72,12 @@ type Exponential struct {
 	maxElapsedTime time.Duration
 	maxInterval    float64
 	maxRetries     int
-	random         *rand.Rand
 	threshold      time.Duration // max backoff
 }
 
 type exponentialBackoff struct {
 	*baseBackoff
 	policy  *Exponential
+	random  *rand.Rand
 	attempt float64
 }


### PR DESCRIPTION
Currently, the exponential backoff uses a random source from the policy, shared between all backoffs. This means that concurrent use of several backoffs from the same policy will lead to a race condition.

From the documentation of the `math/rand` package:

```
The default Source is safe for concurrent use by multiple goroutines, but Sources created by NewSource are not.
```

Rather than using the default source, which would need seeding and could thus interfere with the intentional seeding by a program using the package, I thought it was cleaner to simply have one random source per exponential backoff.