### PR TITLE
Fix the jitter calculation in the exponential policy

### DIFF
--- a/v2/exponential.go
+++ b/v2/exponential.go
@@ -89,7 +89,7 @@ func (g *ExponentialInterval) Next() time.Duration {
 		jitterMin := next - jitterDelta
 		jitterMax := next + jitterDelta
 
-		next = jitterMin + g.rng.Float64()*(jitterMax-jitterMin+1)
+		next = jitterMin + g.rng.Float64()*(jitterMax-jitterMin)
 	}
 
 	g.current = next
@@ -124,4 +124,3 @@ func (p *ExponentialPolicy) Start(ctx context.Context) Controller {
 	ig := NewExponentialInterval(p.igOptions...)
 	return newController(ctx, ig, p.cOptions...)
 }
-


### PR DESCRIPTION
Until this pull-request, if the interval value is `1` (1 ns) and jitter factor is `0.5` (i.e. 50%), a values range becomes `[0.5, 2.5)`. This range is not within 50% variation.
This issue is relieved if the interval value is big, but on the other hand, the issue is remarkable if the value is small.
This p-r removes unnecessary `+1` from random value derivation.