### PR TITLE
Tweak range tests

### DIFF
--- a/backoff_test.go
+++ b/backoff_test.go
@@ -62,8 +62,8 @@ func TestConstant(t *testing.T) {
 }
 
 func isInErrorRange(expected, observed, margin time.Duration) bool {
-	return expected+margin > observed &&
-		observed > expected-margin
+	return expected+margin >= observed &&
+		observed >= expected-margin
 }
 
 func TestExponential(t *testing.T) {


### PR DESCRIPTION
Allow observed durations to be exactly at the edge values