### PR TITLE
fix goroutine leak at NullPolicy

### DIFF
--- a/null.go
+++ b/null.go
@@ -31,7 +31,10 @@ func newNullController(ctx context.Context) *nullController {
 		next: make(chan struct{}), // NO BUFFER
 	}
 	go func(ch chan struct{}, cancel func()) {
-		ch <- struct{}{}
+		select {
+		case <-c.ctx.Done():
+		case ch <- struct{}{}:
+		}
 		close(ch)
 		cancel()
 	}(c.next, cancel)

--- a/null_test.go
+++ b/null_test.go
@@ -1,0 +1,34 @@
+package backoff_test
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/lestrrat-go/backoff/v2"
+)
+
+func TestLeakNull(t *testing.T) {
+	beforeGoroutine := runtime.NumGoroutine()
+	var wg sync.WaitGroup
+	tasks := 100
+	wg.Add(tasks)
+	for range make([]struct{}, tasks) {
+		go func() {
+			defer wg.Done()
+			null := backoff.Null()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			c := null.Start(ctx)
+			for backoff.Continue(c) {
+				return
+			}
+		}()
+	}
+	wg.Wait()
+	afterGoroutine := runtime.NumGoroutine()
+	if afterGoroutine > beforeGoroutine+10 {
+		t.Errorf("goroutines seem to be leaked. before: %d, after: %d", beforeGoroutine, afterGoroutine)
+	}
+}


### PR DESCRIPTION
fixed goroutine leak at NullPolicy when context is canceled before backoff.Continue
