### PR TITLE
Fix build failure on 32bit systems

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -10,22 +10,22 @@ type controller struct {
 	ctx        context.Context
 	cancel     func()
 	ig         IntervalGenerator
-	maxRetries int
+	maxRetries int64
 	mu         *sync.RWMutex
 	next       chan struct{} // user-facing channel
 	resetTimer chan time.Duration
-	retries    int
+	retries    int64
 	timer      *time.Timer
 }
 
 func newController(ctx context.Context, ig IntervalGenerator, options ...ControllerOption) *controller {
 	cctx, cancel := context.WithCancel(ctx) // DO NOT fire this cancel here
 
-	maxRetries := 10
+	maxRetries := int64(10)
 	for _, option := range options {
 		switch option.Ident() {
 		case identMaxRetries{}:
-			maxRetries = option.Value().(int)
+			maxRetries = option.Value().(int64)
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -76,7 +76,7 @@ func (*commonOption) exponentialOption() {}
 // of each policy.
 //
 // This option can be passed to all policy constructors except for NullPolicy
-func WithMaxRetries(v int) ControllerOption {
+func WithMaxRetries(v int64) ControllerOption {
 	return &controllerOption{option.New(identMaxRetries{}, v)}
 }
 


### PR DESCRIPTION
This library was recently packaged for Debian, and there is a build failure on 32bit systems (full log [available here](https://ci.debian.net/packages/g/golang-github-lestrrat-go-backoff/testing/i386/49670801/)). This PR explicitly changes a few variables to `int64` ensuring the same integer size on both 32bit and 64bit systems.